### PR TITLE
Content-Length header for unicode strings

### DIFF
--- a/lib/amon.js
+++ b/lib/amon.js
@@ -46,7 +46,7 @@ var Amon = {
 	post_http: function(type, data) {
 
         var headers = {
-            'Content-Length' : data.length,
+            'Content-Length' : Buffer.byteLength(data),
             'Content-Type': 'application/x-www-form-urlencoded'
         };
 


### PR DESCRIPTION
`Content-Length` header set incorrectly when `tags` or `message` contain non-ascii characters.
